### PR TITLE
Linux Cookie Compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
-
-Copy code
-# Ignore everything
-*
-
-# But not these files...
+# Exclude everything but core Python files and readme to avoid 
+# pushing crawled data.
+/*
+!/src
 !.gitignore
 !*.py
 !requirements.txt

--- a/src/login_script.py
+++ b/src/login_script.py
@@ -14,6 +14,7 @@ def get_cookiefile():
     default_cookiefile = {
         "Windows": "~/AppData/Roaming/Mozilla/Firefox/Profiles/*/cookies.sqlite",
         "Darwin": "~/Library/Application Support/Firefox/Profiles/*/cookies.sqlite",
+        "Linux": "~/snap/firefox/common/.mozilla/firefox/*/cookies.sqlite",
     }.get(system(), "~/.mozilla/firefox/*/cookies.sqlite")
     cookiefiles = glob(expanduser(default_cookiefile))
     if not cookiefiles:


### PR DESCRIPTION
Adds Firefox cookie location for snap installations on Linux OS, tested on an Ubuntu VM. Revises .gitignore, as the previous config was set to ignore source code changes in the repository.